### PR TITLE
fix: register `marketplace` command group in CLI

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from collect import collect
 from llm_config import configure_cmd, models_cmd
 from mcp import mcp
 from memory import memory
-from share import install
+from share import install, marketplace
 from skill import skill
 from status import status
 from sync_helpers import count_installed_skills, resolve_target_tools, sync_all
@@ -54,6 +54,7 @@ cli.add_command(memory)
 
 # Install
 cli.add_command(install)
+cli.add_command(marketplace)
 
 # MCP
 cli.add_command(mcp)


### PR DESCRIPTION
## Problem
The `marketplace` Click group was defined in `src/share.py` but never added to the main CLI in `src/main.py`. Running `apc marketplace` returned `Error: No such command 'marketplace'.`

## Fix
Import `marketplace` from `share` and register it with `cli.add_command(marketplace)`.

## Changes
- `src/main.py`: add `marketplace` to import and register as top-level command

## Testing
```bash
apc marketplace --help       # now works
apc marketplace list         # lists configured sources
apc marketplace add owner/repo  # adds a source
apc marketplace delete owner/repo  # removes a source
```

Closes #1