### PR TITLE
fix: sync exits non-zero and omits success message on complete failure

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -121,7 +121,9 @@ def sync(tools, apply_all, no_memory, override_mcp, dry_run, yes):
             info("Cancelled.")
             return
 
-    sync_all(tool_list, no_memory=no_memory, override_mcp=override_mcp)
+    ok = sync_all(tool_list, no_memory=no_memory, override_mcp=override_mcp)
+    if not ok:
+        raise SystemExit(1)
 
 
 def main():

--- a/src/sync_helpers.py
+++ b/src/sync_helpers.py
@@ -153,8 +153,11 @@ def sync_memory(tool_list: List[str]) -> int:
     return total
 
 
-def sync_all(tool_list: List[str], no_memory: bool = False, override_mcp: bool = False) -> None:
-    """Apply everything (skills + MCP + memory). Used by `apc sync`."""
+def sync_all(tool_list: List[str], no_memory: bool = False, override_mcp: bool = False) -> bool:
+    """Apply everything (skills + MCP + memory). Used by `apc sync`.
+
+    Returns True if at least one tool was synced successfully, False otherwise.
+    """
     bundle = load_local_bundle()
     collected_skills = bundle["skills"]
     mcp_servers = bundle["mcp_servers"]
@@ -173,6 +176,7 @@ def sync_all(tool_list: List[str], no_memory: bool = False, override_mcp: bool =
     total_skills = 0
     total_mcp = 0
     total_memory = 0
+    failed_tools = []
 
     for tool_name in tool_list:
         try:
@@ -204,7 +208,14 @@ def sync_all(tool_list: List[str], no_memory: bool = False, override_mcp: bool =
             success(f"{tool_name}: {s + lk} skills, {m} MCP servers, {mem} memory files")
         except Exception as e:
             error(f"Failed to apply to {tool_name}: {e}")
+            failed_tools.append(tool_name)
 
-    success(
-        f"\nSynced: {total_skills} skills, {total_mcp} MCP servers, {total_memory} memory files"
-    )
+    any_success = len(failed_tools) < len(tool_list)
+    if any_success:
+        success(
+            f"\nSynced: {total_skills} skills, {total_mcp} MCP servers, {total_memory} memory files"
+        )
+    elif failed_tools:
+        warning(f"\nSync failed for all tools: {', '.join(failed_tools)}")
+
+    return any_success


### PR DESCRIPTION
## Problem
`apc sync` exited with code 0 and printed `✓ Synced: 0 skills, 0 MCP servers, 0 memory files` even when all target tools failed. This broke shell scripting and misled users.

## Fix
- `sync_all()` now returns `bool` (True = at least one tool succeeded)
- **Total failure** → prints a warning and exits with code 1
- **Partial success** → success summary shown for succeeded tools; warning for failed ones
- **Full success** → unchanged behaviour

## Changes
- `src/sync_helpers.py`: track failed tools, return success bool, conditional messaging
- `src/main.py`: use return value to `raise SystemExit(1)` on total failure

## Testing
Covered by `TestSync::test_sync_exits_nonzero_on_total_failure` and `test_sync_partial_success` in `tests/test_docker_integration.py`.

Closes #2