### PR TITLE
fix: deduplicate MCP servers by name only

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -107,5 +107,12 @@ def merge_memory(existing: List[Dict], new: List[Dict]) -> List[Dict]:
     return list(index.values())
 
 
-def _key_mcp(s: Dict) -> tuple:
-    return (s.get("source_tool", ""), s.get("name", ""))
+def _key_mcp(s: Dict) -> str:
+    """Deduplicate MCP servers by name only.
+
+    The same logical MCP server can be collected from multiple tools
+    (e.g. a shared server configured in both Claude and Cursor). Keying
+    by name alone ensures we keep one canonical entry (last collected wins)
+    instead of accumulating one entry per source tool.
+    """
+    return s.get("name", "")


### PR DESCRIPTION
## Problem
`merge_mcp_servers` keyed entries by `(source_tool, name)`, so the same logical MCP server collected from multiple tools created separate cache entries. In practice, 5 unique servers produced 13 cache entries, causing bloated configs and duplicate server registrations on sync.

## Fix
Change `_key_mcp` to key by `name` alone. Last-collected entry wins. 13 entries → 5 entries for the same tool set.

## Trade-off
If two tools have genuinely different configs under the same server name, last-collected wins. Users can control precedence by running `apc collect --tools <preferred>` last, or using `--override-mcp` on sync.

## Changes
- `src/cache.py`: change `_key_mcp` return from `tuple[str, str]` to `str`

## Testing
Covered by `TestSubSync` deduplication tests in `tests/test_docker_integration.py`.

Closes #4