### PR TITLE
fix: remove duplicate system prompt in `_call_claude_cli`

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -113,16 +113,11 @@ def _call_claude_cli(
     _strip_vars = {"CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"}
     env = {k: v for k, v in os.environ.items() if k not in _strip_vars}
 
-    # Embed system instruction directly in the prompt for strongest effect
-    full_prompt = prompt
-    if system:
-        full_prompt = f"<instructions>{system}</instructions>\n\n{prompt}"
-
     # Write prompt to a temp file to avoid OS arg length limits
     import tempfile
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, encoding="utf-8") as f:
-        f.write(full_prompt)
+        f.write(prompt)
         prompt_file = f.name
 
     cmd = [


### PR DESCRIPTION
## Problem
In `_call_claude_cli`, the system prompt was injected twice:
1. Embedded in the user prompt as `<instructions>…</instructions>` XML
2. Also passed as `--append-system-prompt` to the Claude CLI

The model saw the same instruction twice on every LLM call, degrading output quality and wasting tokens.

## Fix
Remove the XML wrapper. Pass the system prompt **only** via `--append-system-prompt` — the correct structured channel for the Claude CLI.

## Changes
- `src/llm_client.py`: remove `full_prompt` XML construction; use plain `prompt` as stdin input

Closes #5