### PR TITLE
fix: validate `--tools` flag rejects empty string

### DIFF
--- a/src/collect.py
+++ b/src/collect.py
@@ -73,8 +73,11 @@ def collect(tools, no_memory, yes):
     # --- Phase 1: Scan ---
     header("Scanning")
 
-    if tools:
-        tool_list = [t.strip() for t in tools.split(",")]
+    if tools is not None:
+        tool_list = [t.strip() for t in tools.split(",") if t.strip()]
+        if not tool_list:
+            error("--tools requires at least one tool name (e.g. --tools claude,cursor)")
+            return
     else:
         tool_list = detect_installed_tools()
 

--- a/src/sync_helpers.py
+++ b/src/sync_helpers.py
@@ -31,8 +31,12 @@ def count_installed_skills() -> int:
 
 def resolve_target_tools(tools_flag: Optional[str], apply_all: bool) -> List[str]:
     """Resolve target tools from --tools flag, --all flag, or interactive selection."""
-    if tools_flag:
-        return [t.strip() for t in tools_flag.split(",")]
+    if tools_flag is not None:
+        tool_list = [t.strip() for t in tools_flag.split(",") if t.strip()]
+        if not tool_list:
+            warning("--tools requires at least one tool name (e.g. --tools cursor,gemini)")
+            return []
+        return tool_list
 
     if apply_all:
         tool_list = detect_installed_tools()


### PR DESCRIPTION
## Problem
`apc collect --tools ""` and `apc sync --tools ""` silently fell back to scanning/targeting all detected tools. An empty string is falsy in Python, so the `if tools:` guard fell through to `detect_installed_tools()` — identical behaviour to omitting the flag entirely. This was surprising and bug-prone for scripts that build `--tools` dynamically.

## Fix
Change guard from `if tools:` to `if tools is not None:`. Filter empty tokens, then raise a clear error if the resulting list is empty.

## Changes
- `src/collect.py`: validate `--tools` produces at least one non-empty name
- `src/sync_helpers.py`: same validation in `resolve_target_tools`

## Testing
Covered by `TestCollect::test_collect_empty_tools_flag_errors` and `TestSync::test_sync_empty_tools_errors` in `tests/test_docker_integration.py`.

Closes #6