### PR TITLE
fix(#32,#35): chmod 600 MCP config files, scrub secrets from export

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "APC CLI gitleaks config"
+
+[extend]
+# Use gitleaks default ruleset as the base
+useDefault = true
+
+[[allowlists]]
+description = "Test files that deliberately contain fake token patterns to test secret-scrubbing"
+paths = [
+    '''tests/test_security_secret_handling\.py''',
+]

--- a/src/appliers/claude.py
+++ b/src/appliers/claude.py
@@ -1,6 +1,8 @@
 """Claude Code applier — writes skills, MCP, memory, settings."""
 
 import json
+import os
+import stat
 from pathlib import Path
 from typing import Dict, List
 
@@ -125,7 +127,10 @@ class ClaudeApplier(BaseApplier):
             count += 1
 
         data["mcpServers"] = mcp_servers
-        _claude_json().write_text(json.dumps(data, indent=2), encoding="utf-8")
+        target = _claude_json()
+        target.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Restrict to owner-only since the file may contain resolved API keys (#32)
+        os.chmod(target, stat.S_IRUSR | stat.S_IWUSR)
         return count
 
     def _read_existing_memory_files(self) -> Dict[str, str]:

--- a/src/appliers/copilot.py
+++ b/src/appliers/copilot.py
@@ -1,6 +1,8 @@
 """GitHub Copilot applier — writes instructions and MCP configs."""
 
 import json
+import os
+import stat
 from pathlib import Path
 from typing import Dict, List
 
@@ -141,8 +143,11 @@ class CopilotApplier(BaseApplier):
             count += 1
 
         data["servers"] = vscode_servers
-        VSCODE_MCP_JSON.parent.mkdir(parents=True, exist_ok=True)
-        VSCODE_MCP_JSON.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        vscode_mcp = Path(VSCODE_MCP_JSON).resolve()
+        vscode_mcp.parent.mkdir(parents=True, exist_ok=True)
+        vscode_mcp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Restrict to owner-only since the file may contain resolved API keys (#32)
+        os.chmod(vscode_mcp, stat.S_IRUSR | stat.S_IWUSR)
         return count
 
     def _read_existing_memory_files(self) -> Dict[str, str]:

--- a/src/appliers/cursor.py
+++ b/src/appliers/cursor.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 from pathlib import Path
 from typing import Dict, List
 
@@ -180,6 +181,8 @@ class CursorApplier(BaseApplier):
         data["mcpServers"] = mcp_servers
         mcp_json.parent.mkdir(parents=True, exist_ok=True)
         mcp_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Restrict to owner-only since the file may contain resolved API keys (#32)
+        os.chmod(mcp_json, stat.S_IRUSR | stat.S_IWUSR)
         return count
 
     def _read_existing_memory_files(self) -> Dict[str, str]:

--- a/src/appliers/gemini.py
+++ b/src/appliers/gemini.py
@@ -1,6 +1,8 @@
 """Gemini CLI applier — writes MCP server configs and settings."""
 
 import json
+import os
+import stat
 from pathlib import Path
 from typing import Dict, List
 
@@ -132,7 +134,10 @@ class GeminiApplier(BaseApplier):
 
         data["mcpServers"] = mcp_servers
         _gemini_dir().mkdir(parents=True, exist_ok=True)
-        _gemini_settings().write_text(json.dumps(data, indent=2), encoding="utf-8")
+        settings_path = _gemini_settings()
+        settings_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Restrict to owner-only since the file may contain resolved API keys (#32)
+        os.chmod(settings_path, stat.S_IRUSR | stat.S_IWUSR)
         return count
 
     def _read_existing_memory_files(self) -> Dict[str, str]:

--- a/src/appliers/windsurf.py
+++ b/src/appliers/windsurf.py
@@ -1,6 +1,8 @@
 """Windsurf (Codeium) applier — writes MCP server configs and rules."""
 
 import json
+import os
+import stat
 from pathlib import Path
 from typing import Dict, List
 
@@ -148,7 +150,10 @@ class WindsurfApplier(BaseApplier):
 
         data["mcpServers"] = mcp_servers
         _windsurf_dir().mkdir(parents=True, exist_ok=True)
-        _windsurf_mcp_config().write_text(json.dumps(data, indent=2), encoding="utf-8")
+        mcp_config_path = _windsurf_mcp_config()
+        mcp_config_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        # Restrict to owner-only since the file may contain resolved API keys (#32)
+        os.chmod(mcp_config_path, stat.S_IRUSR | stat.S_IWUSR)
         return count
 
     def _read_existing_memory_files(self) -> Dict[str, str]:

--- a/src/export_import.py
+++ b/src/export_import.py
@@ -28,7 +28,7 @@ from cache import (
     save_skills,
 )
 from config import get_config_dir
-from secrets_manager import retrieve_secret, store_secrets_batch
+from secrets_manager import retrieve_secret, scrub_content, store_secrets_batch
 from skills import get_skills_dir
 from ui import error, header, info, success, warning
 
@@ -292,8 +292,13 @@ def export_cmd(path: str, no_secrets: bool, yes: bool):
     (export_dir / "cache").mkdir(exist_ok=True)
     (export_dir / "config").mkdir(exist_ok=True)
 
-    # 1. Cache: skills.json (plain)
-    (export_dir / "cache" / "skills.json").write_text(json.dumps(skills, indent=2, default=str))
+    # 1. Cache: skills.json — scrub secret values from skill body text
+    scrubbed_skills = [
+        {**s, "body": scrub_content(s["body"])} if "body" in s else s for s in skills
+    ]
+    (export_dir / "cache" / "skills.json").write_text(
+        json.dumps(scrubbed_skills, indent=2, default=str)
+    )
 
     # 2. Cache: mcp_servers.json (with encrypted secrets)
     exported_mcp = _export_mcp_servers(mcp_servers, public_key)
@@ -301,8 +306,13 @@ def export_cmd(path: str, no_secrets: bool, yes: bool):
         json.dumps(exported_mcp, indent=2, default=str)
     )
 
-    # 3. Cache: memory.json (plain)
-    (export_dir / "cache" / "memory.json").write_text(json.dumps(memory, indent=2, default=str))
+    # 3. Cache: memory.json — scrub secret values from memory content
+    scrubbed_memory = [
+        {**m, "content": scrub_content(m["content"])} if "content" in m else m for m in memory
+    ]
+    (export_dir / "cache" / "memory.json").write_text(
+        json.dumps(scrubbed_memory, indent=2, default=str)
+    )
 
     # 4. Installed skills directory (resolve symlinks)
     if installed_skills:

--- a/src/secrets_manager.py
+++ b/src/secrets_manager.py
@@ -17,6 +17,29 @@ SECRET_FIELD_PATTERNS = [
     r".*private.*key.*",
 ]
 
+# Regex for values that look like secrets (high-entropy, common token formats)
+_SECRET_VALUE_RE = re.compile(
+    r"(?:"
+    r"sk-[A-Za-z0-9]{20,}"  # OpenAI-style keys
+    r"|sk-ant-[A-Za-z0-9\-]{20,}"  # Anthropic-style keys
+    r"|AIza[A-Za-z0-9_\-]{35,}"  # Google API keys
+    r"|eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+"  # JWT tokens
+    r"|ghp_[A-Za-z0-9]{36,}"  # GitHub personal tokens
+    r"|ghs_[A-Za-z0-9]{36,}"  # GitHub server tokens
+    r"|[A-Za-z0-9+/]{40,}={0,2}"  # Base64-encoded blobs (≥40 chars)
+    r")"
+)
+
+
+def scrub_content(text: str) -> str:
+    """Replace recognisable secret values in *text* with a redaction marker.
+
+    This is a best-effort scan for common token / API-key formats.
+    It does NOT guarantee all secrets are removed — use it as a defence-in-depth
+    layer for export output that might be shared or committed to version control.
+    """
+    return _SECRET_VALUE_RE.sub("[REDACTED]", text)
+
 
 def is_secret_field(field_name: str) -> bool:
     """Check if a field name looks like it contains a secret."""

--- a/src/sync_helpers.py
+++ b/src/sync_helpers.py
@@ -126,6 +126,15 @@ def sync_mcp(tool_list: List[str], override: bool = False) -> int:
         warning("No MCP servers in cache. Run 'apc collect' first.")
         return 0
 
+    # Warn once if any server has secrets that will be written to disk (#32)
+    servers_with_secrets = [s for s in mcp_servers if s.get("secret_placeholders")]
+    if servers_with_secrets:
+        warning(
+            f"{len(servers_with_secrets)} MCP server(s) have secrets that will be resolved "
+            "and written to tool config files (chmod 600). "
+            "Ensure those files are excluded from version control."
+        )
+
     current_mcp_names = [s.get("name", "unnamed") for s in mcp_servers]
     total = 0
 

--- a/tests/test_security_secret_handling.py
+++ b/tests/test_security_secret_handling.py
@@ -1,0 +1,201 @@
+"""Tests for secret-handling security fixes (#32, #35)."""
+
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from appliers.manifest import ToolManifest
+
+
+class TestScrubContent(unittest.TestCase):
+    """#35 — Memory/skill content exported without secret scrubbing."""
+
+    def test_openai_key_redacted(self):
+        from secrets_manager import scrub_content
+
+        # Build fake key at runtime — avoids gitleaks false positive in source
+        fake_key = "sk-" + "Ab1" * 10  # 30 alphanum chars after "sk-"
+        text = f"My key is {fake_key} and it works"
+        result = scrub_content(text)
+        self.assertNotIn(fake_key, result)
+        self.assertIn("[REDACTED]", result)
+
+    def test_anthropic_key_redacted(self):
+        from secrets_manager import scrub_content
+
+        # Build fake Anthropic key at runtime
+        fake_key = "sk-ant-" + "xY9" * 12  # > 20 chars after "sk-ant-"
+        text = f"Use {fake_key}"
+        result = scrub_content(text)
+        self.assertNotIn(fake_key, result)
+        self.assertIn("[REDACTED]", result)
+
+    def test_github_token_redacted(self):
+        from secrets_manager import scrub_content
+
+        # Build fake GitHub PAT at runtime
+        fake_token = "ghp_" + "Az1" * 13  # 39 chars after "ghp_"
+        text = f"TOKEN={fake_token}"
+        result = scrub_content(text)
+        self.assertNotIn(fake_token, result)
+        self.assertIn("[REDACTED]", result)
+
+    def test_plain_text_unchanged(self):
+        from secrets_manager import scrub_content
+
+        text = "This is a normal sentence with no secrets."
+        result = scrub_content(text)
+        self.assertEqual(result, text)
+
+    def test_short_base64_unchanged(self):
+        """Short base64 strings (e.g. checksums) should NOT be redacted."""
+        from secrets_manager import scrub_content
+
+        text = "checksum: dGVzdA=="  # 8 chars, way below 40-char threshold
+        result = scrub_content(text)
+        self.assertEqual(result, text)
+
+
+class TestExportScrubsContent(unittest.TestCase):
+    """#35 — Export must scrub recognizable secret patterns from memory/skills."""
+
+    def test_memory_content_scrubbed_on_export(self):
+        """Memory entries with API-key-shaped values get redacted in export."""
+        from secrets_manager import scrub_content
+
+        # Build fake key at runtime to avoid gitleaks false positives in source
+        fake_key = "sk-" + "t3st" * 7  # 28 chars after "sk-", matches scrub pattern
+        secret_content = f"Use this key: {fake_key}"
+        scrubbed = scrub_content(secret_content)
+        self.assertNotIn(fake_key, scrubbed)
+        self.assertIn("[REDACTED]", scrubbed)
+
+    def test_skill_body_scrubbed_on_export(self):
+        """Skill body text with embedded keys gets redacted in export."""
+        from secrets_manager import scrub_content
+
+        # Build fake key at runtime to avoid gitleaks false positives in source
+        fake_key = "sk-" + "Abc9" * 6  # 24 chars after "sk-"
+        skill_body = f"OPENAI_KEY={fake_key}"
+        scrubbed = scrub_content(skill_body)
+        self.assertNotIn(fake_key, scrubbed)
+
+
+class TestMcpConfigPermissions(unittest.TestCase):
+    """#32 — MCP config files must be chmod 600 after writing resolved secrets."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.manifest_path = self.tmpdir / "manifest.json"
+
+    def _manifest(self, tool: str = "cursor") -> ToolManifest:
+        return ToolManifest(tool, path=self.manifest_path)
+
+    def test_cursor_mcp_json_chmod_600(self):
+        mcp_json = self.tmpdir / "mcp.json"
+        servers = [
+            {
+                "name": "fs",
+                "transport": "stdio",
+                "command": "npx",
+                "args": [],
+                "env": {"TOKEN": "resolved-secret"},
+            }
+        ]
+        manifest = self._manifest("cursor")
+
+        with patch("appliers.cursor._cursor_mcp_json", return_value=mcp_json):
+            from appliers.cursor import CursorApplier
+
+            applier = CursorApplier()
+            applier.apply_mcp_servers(servers, {}, manifest)
+
+        file_mode = oct(stat.S_IMODE(os.stat(mcp_json).st_mode))
+        self.assertEqual(file_mode, oct(0o600), f"Expected 600, got {file_mode}")
+
+    def test_gemini_settings_chmod_600(self):
+        settings = self.tmpdir / "settings.json"
+        servers = [
+            {
+                "name": "svc",
+                "transport": "stdio",
+                "command": "node",
+                "args": [],
+                "env": {},
+            }
+        ]
+        manifest = self._manifest("gemini-cli")
+
+        with (
+            patch("appliers.gemini._gemini_settings", return_value=settings),
+            patch("appliers.gemini._gemini_dir", return_value=self.tmpdir),
+        ):
+            from appliers.gemini import GeminiApplier
+
+            applier = GeminiApplier()
+            applier.apply_mcp_servers(servers, {}, manifest)
+
+        file_mode = oct(stat.S_IMODE(os.stat(settings).st_mode))
+        self.assertEqual(file_mode, oct(0o600), f"Expected 600, got {file_mode}")
+
+    def test_claude_json_chmod_600(self):
+        claude_json = self.tmpdir / ".claude.json"
+        servers = [
+            {
+                "name": "mcp-srv",
+                "transport": "stdio",
+                "command": "node",
+                "args": [],
+                "env": {},
+            }
+        ]
+        manifest = self._manifest("claude-code")
+
+        with patch("appliers.claude._claude_json", return_value=claude_json):
+            from appliers.claude import ClaudeApplier
+
+            applier = ClaudeApplier()
+            applier.apply_mcp_servers(servers, {}, manifest)
+
+        file_mode = oct(stat.S_IMODE(os.stat(claude_json).st_mode))
+        self.assertEqual(file_mode, oct(0o600), f"Expected 600, got {file_mode}")
+
+
+class TestSyncMcpWarnsAboutSecrets(unittest.TestCase):
+    """#32 — sync_mcp should warn when servers have secrets being written to disk."""
+
+    def test_warns_when_servers_have_secrets(self):
+        servers = [
+            {"name": "fs", "transport": "stdio", "command": "npx", "secret_placeholders": ["TOKEN"]}
+        ]
+        warnings = []
+
+        with (
+            patch("sync_helpers.load_mcp_servers", return_value=servers),
+            patch("sync_helpers.get_applier") as mock_get_applier,
+            patch("sync_helpers.warning", side_effect=lambda m: warnings.append(m)),
+            patch("sync_helpers._resolve_all_mcp_secrets", return_value={"TOKEN": "secret"}),
+        ):
+            mock_applier = unittest.mock.MagicMock()
+            mock_applier.get_manifest.return_value = ToolManifest(
+                "cursor", path=Path(tempfile.mkdtemp()) / "m.json"
+            )
+            mock_applier.apply_mcp_servers.return_value = 1
+            mock_get_applier.return_value = mock_applier
+
+            from sync_helpers import sync_mcp
+
+            sync_mcp(["cursor"])
+
+        # At least one warning about secrets being written to disk
+        self.assertTrue(
+            any("secret" in w.lower() for w in warnings),
+            f"Expected a secrets warning, got: {warnings}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #32, Fixes #35

### #32 — MCP sync writes resolved secrets to plaintext tool config files
All MCP server JSON config files written by appliers (Claude, Cursor, Gemini, Windsurf, Copilot) are now set to chmod 600 immediately after write. Secrets are still injected so tools can start MCP servers, but access is restricted to the file owner. sync_mcp() now emits an explicit warning when servers with secret placeholders are being resolved and written to disk.

### #35 — Memory and skill content exported in plaintext without secret scrubbing  
Added scrub_content() to secrets_manager.py using regexes to detect common API-key/token patterns (OpenAI sk-, Anthropic sk-ant-, GitHub ghp_/ghs_, JWTs, long base64 blobs). export_cmd() calls scrub_content() on every skill body and memory content entry before writing the export archive.

### Tests
11 new tests in test_security_secret_handling.py:
- scrub_content() detects/redacts OpenAI, Anthropic, GitHub token patterns
- Plain text and short base64 are not affected  
- chmod 600 verified on Claude, Cursor, Gemini appliers
- sync_mcp() emits a warning when servers have secret_placeholders