### PR TITLE
chore: add CODEOWNERS — all PRs require FZ2000 approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require FZ2000 approval
+* @FZ2000


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so that every file in the repo requires **@FZ2000** approval before merging.\n\nThis works together with the branch protection rule already set:\n- `require_code_owner_reviews: true`\n- `required_approving_review_count: 1`\n\n**You need to approve and merge this PR to activate the rule for all future PRs.**