### PR TITLE
chore: add CODEOWNERS — all PRs require FZ2000 approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files require FZ2000 approval
+* @FZ2000


### PR DESCRIPTION
Adds .github/CODEOWNERS so all PRs require @FZ2000 approval before merging.